### PR TITLE
Fix some issues with the current track syncing system.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ minecraft {
     mappings channel: 'snapshot', version: '20200916-1.16.2'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 
-    accessTransformer = file('src/api/resources/META-INF/accesstransformer.cfg')
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     // Default run configurations.
     // These can be tweaked, removed, or duplicated as needed.

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ minecraft {
     mappings channel: 'snapshot', version: '20200916-1.16.2'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 
-    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+    accessTransformer = file('src/api/resources/META-INF/accesstransformer.cfg')
 
     // Default run configurations.
     // These can be tweaked, removed, or duplicated as needed.

--- a/src/main/java/me/ichun/mods/clef/client/gui/GuiPlayTrack.java
+++ b/src/main/java/me/ichun/mods/clef/client/gui/GuiPlayTrack.java
@@ -28,6 +28,7 @@ import org.lwjgl.glfw.GLFW;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class GuiPlayTrack extends Screen
 {
@@ -56,7 +57,7 @@ public class GuiPlayTrack extends Screen
     public int index = -1;
     public int doneTimeout = 0;
 
-    public ArrayList<TrackFile> tracks;
+    public List<TrackFile> tracks;
     public String bandNameString = "";
 
     public int scrollTicker = 0;
@@ -71,7 +72,7 @@ public class GuiPlayTrack extends Screen
     public GuiPlayTrack()
     {
         super(new TranslationTextComponent("clef.gui.chooser"));
-        tracks = AbcLibrary.tracks;
+        tracks = AbcLibrary.getTracks();
         bandNameString = Clef.configClient.favoriteBand;
     }
 

--- a/src/main/java/me/ichun/mods/clef/client/gui/GuiPlayTrackBlock.java
+++ b/src/main/java/me/ichun/mods/clef/client/gui/GuiPlayTrackBlock.java
@@ -189,6 +189,7 @@ public class GuiPlayTrackBlock extends GuiPlayTrack
         super.render(stack, mouseX, mouseY, partialTicks);
 
         stack.push();
+        RenderSystem.pushMatrix();
         RenderSystem.translatef((float)guiLeft, (float)guiTop, 0.0F); //matrix stack not taken into account by all vanilla methods rn, so we need the RenderSystem (see ContainerScreen)
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.enableRescaleNormal();
@@ -218,6 +219,7 @@ public class GuiPlayTrackBlock extends GuiPlayTrack
         }
 
         stack.pop();
+        RenderSystem.popMatrix();
 
         RenderSystem.disableLighting();
         RenderSystem.disableDepthTest();

--- a/src/main/java/me/ichun/mods/clef/client/gui/GuiPlayTrackBlock.java
+++ b/src/main/java/me/ichun/mods/clef/client/gui/GuiPlayTrackBlock.java
@@ -7,6 +7,7 @@ import me.ichun.mods.clef.common.Clef;
 import me.ichun.mods.clef.common.inventory.ContainerInstrumentPlayer;
 import me.ichun.mods.clef.common.packet.PacketInstrumentPlayerInfo;
 import me.ichun.mods.clef.common.tileentity.TileEntityInstrumentPlayer;
+import me.ichun.mods.clef.common.util.abc.BaseTrackFile;
 import me.ichun.mods.clef.common.util.abc.TrackFile;
 import me.ichun.mods.ichunutil.client.core.ResourceHelper;
 import net.minecraft.client.audio.SimpleSound;
@@ -24,6 +25,7 @@ import net.minecraft.util.text.TranslationTextComponent;
 import org.lwjgl.opengl.GL13;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class GuiPlayTrackBlock extends GuiPlayTrack
         implements IHasContainer<ContainerInstrumentPlayer>
@@ -35,7 +37,7 @@ public class GuiPlayTrackBlock extends GuiPlayTrack
 
     public int repeat = 0;
     public int shuffle = 0;
-    public ArrayList<TrackFile> playlist;
+    public List<BaseTrackFile> playlist;
 
     public boolean playlistView = false;
 
@@ -126,7 +128,7 @@ public class GuiPlayTrackBlock extends GuiPlayTrack
                 {
                     if (index > 0)
                     {
-                        TrackFile file = playlist.get(index);
+                        BaseTrackFile file = playlist.get(index);
                         playlist.remove(index);
                         playlist.add(index - 1, file);
                         index--;
@@ -141,7 +143,7 @@ public class GuiPlayTrackBlock extends GuiPlayTrack
                 {
                     if(index < playlist.size() - 1)
                     {
-                        TrackFile file = playlist.get(index);
+                        BaseTrackFile file = playlist.get(index);
                         playlist.remove(index);
                         playlist.add(index + 1, file);
                         index++;
@@ -325,7 +327,7 @@ public class GuiPlayTrackBlock extends GuiPlayTrack
             }
         }
         ArrayList<String> md5s = new ArrayList<>();
-        for(TrackFile track : playlist)
+        for(BaseTrackFile track : playlist)
         {
             md5s.add(track.md5);
         }

--- a/src/main/java/me/ichun/mods/clef/common/core/EventHandlerServer.java
+++ b/src/main/java/me/ichun/mods/clef/common/core/EventHandlerServer.java
@@ -1,8 +1,5 @@
 package me.ichun.mods.clef.common.core;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSerializationContext;
 import me.ichun.mods.clef.common.Clef;
 import me.ichun.mods.clef.common.item.ItemInstrument;
 import me.ichun.mods.clef.common.packet.PacketPlayingTracks;
@@ -10,6 +7,7 @@ import me.ichun.mods.clef.common.tileentity.TileEntityInstrumentPlayer;
 import me.ichun.mods.clef.common.util.abc.AbcLibrary;
 import me.ichun.mods.clef.common.util.abc.TrackFile;
 import me.ichun.mods.clef.common.util.abc.play.Track;
+import me.ichun.mods.clef.common.util.abc.play.components.TrackInfo;
 import me.ichun.mods.clef.common.util.instrument.Instrument;
 import me.ichun.mods.clef.common.util.instrument.InstrumentLibrary;
 import me.ichun.mods.ichunutil.common.iChunUtil;
@@ -20,9 +18,7 @@ import net.minecraft.entity.monster.ZombieEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.loot.ILootSerializer;
 import net.minecraft.loot.LootFunctionType;
-import net.minecraft.loot.functions.ILootFunction;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.Hand;
 import net.minecraft.loot.ItemLootEntry;
@@ -44,6 +40,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 
 public class EventHandlerServer
 {
@@ -152,11 +149,12 @@ public class EventHandlerServer
                 }
                 else
                 {
-                    TrackFile randTrack = AbcLibrary.tracks.get(zombie.getRNG().nextInt(AbcLibrary.tracks.size()));
-                    track = new Track(RandomStringUtils.randomAscii(IOUtil.IDENTIFIER_LENGTH), "zombies", randTrack.md5, randTrack.track, false);
-                    if(track.getTrack().trackLength > 0)
+                    List<TrackFile> tracks = AbcLibrary.getTracks();
+                    TrackFile randTrack = tracks.get(zombie.getRNG().nextInt(tracks.size()));
+                    track = new Track(RandomStringUtils.randomAscii(IOUtil.IDENTIFIER_LENGTH), "zombies", randTrack, false);
+                    if(randTrack.track.trackLength > 0)
                     {
-                        track.playAtProgress(zombie.getRNG().nextInt(track.getTrack().trackLength));
+                        track.playAtProgress(zombie.getRNG().nextInt(randTrack.track.trackLength));
                     }
                     Clef.eventHandlerServer.tracksPlaying.add(track);
                     track.zombies.add(zombie.getEntityId());
@@ -291,7 +289,7 @@ public class EventHandlerServer
         HashSet<Track> tracks = new HashSet<>();
         for(Track track : tracksPlaying)
         {
-            if(track.getTrack() != null) //this means the track is actively played
+            if(track.getTrackFile() != null) //this means the track is actively played
             {
                 tracks.add(track);
             }

--- a/src/main/java/me/ichun/mods/clef/common/packet/PacketInstrumentPlayerInfo.java
+++ b/src/main/java/me/ichun/mods/clef/common/packet/PacketInstrumentPlayerInfo.java
@@ -3,6 +3,8 @@ package me.ichun.mods.clef.common.packet;
 import me.ichun.mods.clef.common.Clef;
 import me.ichun.mods.clef.common.tileentity.TileEntityInstrumentPlayer;
 import me.ichun.mods.clef.common.util.abc.AbcLibrary;
+import me.ichun.mods.clef.common.util.abc.BaseTrackFile;
+import me.ichun.mods.clef.common.util.abc.PendingTrackFile;
 import me.ichun.mods.clef.common.util.abc.TrackFile;
 import me.ichun.mods.ichunutil.common.network.AbstractPacket;
 import net.minecraft.block.BlockState;
@@ -82,16 +84,13 @@ public class PacketInstrumentPlayerInfo extends AbstractPacket
                 instrumentPlayer.tracks.clear();
                 for(String s : abc_md5s)
                 {
-                    TrackFile track = AbcLibrary.getTrack(s);
+                    BaseTrackFile track = AbcLibrary.getTrack(s);
                     if(track == null)
                     {
-                        instrumentPlayer.pending_md5s.add(s);
                         Clef.channel.sendTo(new PacketRequestFile(s, false), player);
+                        track = new PendingTrackFile(s);
                     }
-                    else
-                    {
-                        instrumentPlayer.tracks.add(track);
-                    }
+                    instrumentPlayer.tracks.add(track);
                 }
                 instrumentPlayer.bandName = bandName;
                 instrumentPlayer.syncPlay = syncPlay;

--- a/src/main/java/me/ichun/mods/clef/common/packet/PacketPlayingTracks.java
+++ b/src/main/java/me/ichun/mods/clef/common/packet/PacketPlayingTracks.java
@@ -2,6 +2,8 @@ package me.ichun.mods.clef.common.packet;
 
 import me.ichun.mods.clef.common.Clef;
 import me.ichun.mods.clef.common.util.abc.AbcLibrary;
+import me.ichun.mods.clef.common.util.abc.BaseTrackFile;
+import me.ichun.mods.clef.common.util.abc.PendingTrackFile;
 import me.ichun.mods.clef.common.util.abc.TrackFile;
 import me.ichun.mods.clef.common.util.abc.play.Track;
 import me.ichun.mods.ichunutil.common.network.AbstractPacket;
@@ -34,7 +36,7 @@ public class PacketPlayingTracks extends AbstractPacket
         {
             buf.writeString(track.getId());
             buf.writeString(track.getBandName());
-            buf.writeString(track.getMd5());
+            buf.writeString(track.getTrackFile().md5);
             buf.writeBoolean(track.playing);
             buf.writeInt(track.playProg);
             buf.writeInt(track.players.size());
@@ -70,8 +72,12 @@ public class PacketPlayingTracks extends AbstractPacket
             String id = readString(buf);
             String band = readString(buf);
             String md5 = readString(buf);
-            TrackFile file = AbcLibrary.getTrack(md5);
-            tracks[i] = new Track(id, band, md5, file != null ? file.track : null, true);
+            BaseTrackFile file = AbcLibrary.getTrack(md5);
+            if (file == null)
+            {
+                file = new PendingTrackFile(md5);
+            }
+            tracks[i] = new Track(id, band, file, true);
             tracks[i].playing = buf.readBoolean();
             tracks[i].playProg = buf.readInt();
             int playerCount = buf.readInt();

--- a/src/main/java/me/ichun/mods/clef/common/thread/ThreadReadFiles.java
+++ b/src/main/java/me/ichun/mods/clef/common/thread/ThreadReadFiles.java
@@ -1,11 +1,17 @@
 package me.ichun.mods.clef.common.thread;
 
+import me.ichun.mods.clef.common.Clef;
 import me.ichun.mods.clef.common.util.abc.AbcLibrary;
 import me.ichun.mods.clef.common.util.instrument.InstrumentLibrary;
+import net.minecraft.client.Minecraft;
+import net.minecraft.crash.CrashReport;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
 
 import java.util.concurrent.CountDownLatch;
 
-public class ThreadReadFiles extends Thread
+public class ThreadReadFiles extends Thread implements Thread.UncaughtExceptionHandler
 {
     public final CountDownLatch latch = new CountDownLatch(1);
 
@@ -21,5 +27,20 @@ public class ThreadReadFiles extends Thread
         AbcLibrary.init();
         InstrumentLibrary.init();
         latch.countDown();
+    }
+
+    @Override
+    public UncaughtExceptionHandler getUncaughtExceptionHandler()
+    {
+        return this;
+    }
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e)
+    {
+        Clef.LOGGER.fatal("Clef File Reader Thread crashed!", e);
+        latch.countDown();
+        CrashReport report = new CrashReport("Clef File Reader Thread crashed!", e);
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> Minecraft.getInstance().crashed(report));
     }
 }

--- a/src/main/java/me/ichun/mods/clef/common/util/abc/BaseTrackFile.java
+++ b/src/main/java/me/ichun/mods/clef/common/util/abc/BaseTrackFile.java
@@ -1,0 +1,13 @@
+package me.ichun.mods.clef.common.util.abc;
+
+public abstract class BaseTrackFile {
+    public final String md5;
+
+    protected BaseTrackFile(String md5) {
+        this.md5 = md5;
+    }
+
+    public abstract boolean isSynced();
+
+    public abstract String getTitle();
+}

--- a/src/main/java/me/ichun/mods/clef/common/util/abc/PendingTrackFile.java
+++ b/src/main/java/me/ichun/mods/clef/common/util/abc/PendingTrackFile.java
@@ -1,0 +1,51 @@
+package me.ichun.mods.clef.common.util.abc;
+
+public class PendingTrackFile extends BaseTrackFile
+{
+    private int tries = 0;
+    private final String title;
+
+    public PendingTrackFile(String md5)
+    {
+        this(md5, null);
+    }
+
+    public PendingTrackFile(String md5, String title)
+    {
+        super(md5);
+        this.title = title;
+    }
+
+    @Override
+    public boolean isSynced()
+    {
+        return false;
+    }
+
+    @Override
+    public String getTitle()
+    {
+        if (title != null)
+        {
+            return title;
+        }
+        else
+        {
+            return "{" + md5 + "}";
+        }
+    }
+
+    public TrackFile resolve()
+    {
+        TrackFile file = AbcLibrary.getTrack(md5);
+        if (file != null)
+            return file;
+        tries++;
+        return null;
+    }
+
+    public int getResolveTries()
+    {
+        return tries;
+    }
+}

--- a/src/main/java/me/ichun/mods/clef/common/util/abc/TrackFile.java
+++ b/src/main/java/me/ichun/mods/clef/common/util/abc/TrackFile.java
@@ -4,18 +4,27 @@ import me.ichun.mods.clef.common.util.abc.play.components.TrackInfo;
 
 import java.io.File;
 
-public class TrackFile
+public class TrackFile extends BaseTrackFile
     implements Comparable<TrackFile>
 {
     public final TrackInfo track;
     public final File file;
-    public final String md5;
 
     public TrackFile(TrackInfo track, File file, String md5)
     {
+        super(md5);
         this.track = track;
         this.file = file;
-        this.md5 = md5;
+    }
+
+    @Override
+    public boolean isSynced() {
+        return true;
+    }
+
+    @Override
+    public String getTitle() {
+        return this.track.getTitle();
     }
 
     @Override


### PR DESCRIPTION
1: tracks might get out of order due to server using two different lists for already present songs and songs that need to be synced
2: A client with missing songs does not see non-synced songs in the playlist, and might overwrite the playlist when opening the playlist with songs he doesn't see and closing it again
3: A client does not hear the song the first time it is played when sync was not fast enough, as it is never rechecked if the song is available now
Also, fix a problem related to the ThreadReadFiles:
When an exception is thrown during reading, it was logged, but not processed further, leading to a stale client.
If the reader crashes now, it will properly shutdown Minecraft
This should fix all these issues